### PR TITLE
Added support for templates

### DIFF
--- a/tasks/haxe.js
+++ b/tasks/haxe.js
@@ -148,6 +148,8 @@ module.exports = function(grunt) {
 				cmdStr = assembleCommand(data);
 			}
 
+			cmdStr = grunt.template.process(cmdStr);
+
 			log.write('\nBuilding Haxe project... \n' + cmdStr + '\n');
 			cmd = cmdStr.split(" ").filter(function (s) { return s.length>0; });
 


### PR DESCRIPTION
Added support for string templates so variables can be used in the task definition, ie:
```
haxe: {
    hxml: "<%= pkg.build %>/release.hxml"
}
```